### PR TITLE
(prototype) Added EMT_wptexturize() from WordPress package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# IDE
+/nbproject/*
+/.idea/*

--- a/EMT_wptexturize.php
+++ b/EMT_wptexturize.php
@@ -3,7 +3,7 @@
 /**
  * Part from WordPress Formatting API.
  * 
- * Added for make Web Typography Standards comportable with WordPress hooks
+ * Added for make Web Typography Standards comportable with WordPress filters
  *
  */
 

--- a/EMT_wptexturize.php
+++ b/EMT_wptexturize.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * Part from WordPress Formatting API.
+ * 
+ * Added for make Web Typography Standards comportable with WordPress hooks
+ *
+ */
+
+/**
+ * Replaces common plain text characters into formatted entities
+ * using Eugene Muraev Typograph
+ *
+ * As an example,
+ *
+ *     'cause today's effort makes it worth tomorrow's "holiday" ...
+ *
+ * Becomes:
+ *
+ *     &#8217;cause today&#8217;s effort makes it worth tomorrow&#8217;s &#8220;holiday&#8221; &#8230;
+ *
+ * Code within certain html blocks are skipped.
+ *
+ *
+ * @global array $wp_cockneyreplace Array of formatted entities for certain common phrases
+ * @global array $shortcode_tags
+ * @staticvar array $static_characters
+ * @staticvar array $static_replacements
+ * @staticvar array $default_no_texturize_tags
+ * @staticvar array $default_no_texturize_shortcodes
+ * @staticvar bool  $run_texturize
+ *
+ * @param string $text The text to be formatted
+ * @param bool   $reset Set to true for unit testing. Translated patterns will reset.
+ * @return string The string replaced with html entities
+ */
+function EMT_wptexturize( $text, $reset = false ) {
+	global $wp_cockneyreplace, $shortcode_tags;
+	static $static_characters, $static_replacements,
+		$default_no_texturize_tags, $default_no_texturize_shortcodes, $run_texturize = true;
+
+	// If there's nothing to do, just stop.
+	if ( empty( $text ) || false === $run_texturize ) {
+		return $text;
+	}
+
+	// Set up static variables. Run once only.
+	if ( $reset || ! isset( $static_characters ) ) {
+		/**
+		 * Filter whether to skip running wptexturize().
+		 *
+		 * Passing false to the filter will effectively short-circuit wptexturize().
+		 * returning the original text passed to the function instead.
+		 *
+		 * The filter runs only once, the first time wptexturize() is called.
+		 *
+		 * @since 4.0.0
+		 *
+		 * @see wptexturize()
+		 *
+		 * @param bool $run_texturize Whether to short-circuit wptexturize().
+		 */
+		$run_texturize = apply_filters( 'run_wptexturize', $run_texturize );
+		if ( false === $run_texturize ) {
+			return $text;
+		}
+
+		$default_no_texturize_tags = array('pre', 'code', 'kbd', 'style', 'script', 'tt');
+		$default_no_texturize_shortcodes = array('code');
+		
+		// if a plugin has provided an autocorrect array, use it
+		if ( isset($wp_cockneyreplace) ) {
+			$cockney = array_keys( $wp_cockneyreplace );
+			$cockneyreplace = array_values( $wp_cockneyreplace );
+		} else {
+			$cockney = $cockneyreplace = array();
+		}
+
+		$static_characters = $cockney;
+		$static_replacements = $cockneyreplace;
+	}
+
+	// Must do this every time in case plugins use these filters in a context sensitive manner
+	/**
+	 * Filter the list of HTML elements not to texturize.
+	 *
+	 * @since 2.8.0
+	 *
+	 * @param array $default_no_texturize_tags An array of HTML element names.
+	 */
+	$no_texturize_tags = apply_filters( 'no_texturize_tags', $default_no_texturize_tags );
+	/**
+	 * Filter the list of shortcodes not to texturize.
+	 *
+	 * @since 2.8.0
+	 *
+	 * @param array $default_no_texturize_shortcodes An array of shortcode names.
+	 */
+	$no_texturize_shortcodes = apply_filters( 'no_texturize_shortcodes', $default_no_texturize_shortcodes );
+
+	$no_texturize_tags_stack = array();
+	$no_texturize_shortcodes_stack = array();
+
+	// Look for shortcodes and HTML elements.
+
+	$tagnames = array_keys( $shortcode_tags );
+	$tagregexp = join( '|', array_map( 'preg_quote', $tagnames ) );
+	$tagregexp = "(?:$tagregexp)(?![\\w-])"; // Excerpt of get_shortcode_regex().
+
+	$comment_regex =
+		  '!'           // Start of comment, after the <.
+		. '(?:'         // Unroll the loop: Consume everything until --> is found.
+		.     '-(?!->)' // Dash not followed by end of comment.
+		.     '[^\-]*+' // Consume non-dashes.
+		. ')*+'         // Loop possessively.
+		. '(?:-->)?';   // End of comment. If not found, match all input.
+
+	$shortcode_regex =
+		  '\['              // Find start of shortcode.
+		. '[\/\[]?'         // Shortcodes may begin with [/ or [[
+		. $tagregexp        // Only match registered shortcodes, because performance.
+		. '(?:'
+		.     '[^\[\]<>]+'  // Shortcodes do not contain other shortcodes. Quantifier critical.
+		. '|'
+		.     '<[^\[\]>]*>' // HTML elements permitted. Prevents matching ] before >.
+		. ')*+'             // Possessive critical.
+		. '\]'              // Find end of shortcode.
+		. '\]?';            // Shortcodes may end with ]]
+
+	$regex =
+		  '/('                   // Capture the entire match.
+		.     '<'                // Find start of element.
+		.     '(?(?=!--)'        // Is this a comment?
+		.         $comment_regex // Find end of comment.
+		.     '|'
+		.         '[^>]*>'       // Find end of element.
+		.     ')'
+		. '|'
+		.     $shortcode_regex   // Find shortcodes.
+		. ')/s';
+
+	$textarr = preg_split( $regex, $text, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY );
+
+	foreach ( $textarr as &$curl ) {
+		// Only call _wptexturize_pushpop_element if $curl is a delimiter.
+		$first = $curl[0];
+		if ( '<' === $first && '<!--' === substr( $curl, 0, 4 ) ) {
+			// This is an HTML comment delimeter.
+
+			continue;
+
+		} elseif ( '<' === $first && '>' === substr( $curl, -1 ) ) {
+			// This is an HTML element delimiter.
+
+			_wptexturize_pushpop_element( $curl, $no_texturize_tags_stack, $no_texturize_tags );
+
+		} elseif ( '' === trim( $curl ) ) {
+			// This is a newline between delimiters.  Performance improves when we check this.
+
+			continue;
+
+		} elseif ( '[' === $first && 1 === preg_match( '/^' . $shortcode_regex . '$/', $curl ) ) {
+			// This is a shortcode delimiter.
+
+			if ( '[[' !== substr( $curl, 0, 2 ) && ']]' !== substr( $curl, -2 ) ) {
+				// Looks like a normal shortcode.
+				_wptexturize_pushpop_element( $curl, $no_texturize_shortcodes_stack, $no_texturize_shortcodes );
+			} else {
+				// Looks like an escaped shortcode.
+				continue;
+			}
+
+		} elseif ( empty( $no_texturize_shortcodes_stack ) && empty( $no_texturize_tags_stack ) ) {
+			// This is neither a delimiter, nor is this content inside of no_texturize pairs.  Do texturize.
+
+			$curl = str_replace( $static_characters, $static_replacements, $curl );
+			
+			// Run EMT
+			$curl = EMT_run( $curl );
+		}
+	}
+	$text = implode( '', $textarr );
+
+	return $text;
+}
+

--- a/plugin.php
+++ b/plugin.php
@@ -15,8 +15,11 @@ http://www.ram108.ru/donate
 OM SAI RAM
 */
 
-// init typo
+// Load libraries
 require_once('EMT.php');
+require_once('EMT_wptexturize.php');
+
+// Init typograph
 $ram108_typo = new EMTypograph();
 $ram108_typo->setup(array(
 	'Text.paragraphs'		=> 'off',
@@ -24,20 +27,33 @@ $ram108_typo->setup(array(
 	'OptAlign.all'			=> 'off',
 ));
 
-// new wptextorize function with typo
-function ram108_typo_wptexturize( $text ){
+/**
+ * Run EMT on selected text
+ * @global EMTypograph $ram108_typo
+ * @param string $text
+ * @return string
+ */
+function EMT_run( $text ){
 	global $ram108_typo;
 	$ram108_typo->set_text( $text );
 	return $ram108_typo->apply();
 }
 
-// change all wptexturize filters to ram108_typo_wptexturize
+/**
+ * Change all wptexturize filters to EMT_wptexturize
+ * @global string $wp_filter
+ */
 function ram108_typo_change_filter(){
 	global $wp_filter;
-	foreach ( $wp_filter as $tag => $filter_list )
-	foreach ( $filter_list as $priority => $data )
-	foreach ( $data as $id => $func )
-	if ( 'wptexturize' == $id ) $wp_filter[ $tag ] [ $priority ] [ $id ] ['function'] = 'ram108_typo_wptexturize';
+	foreach ( $wp_filter as $tag => $filter_list ) {
+		foreach ( $filter_list as $priority => $data ) {
+			foreach ( $data as $id => $func ) {
+				if ( 'wptexturize' == $id ) {
+					$wp_filter[ $tag ] [ $priority ] [ $id ] ['function'] = 'EMT_wptexturize';
+				}
+			}
+		}
+	}
 }
 
 // activate plugin

--- a/plugin.php
+++ b/plugin.php
@@ -40,6 +40,33 @@ function EMT_run( $text ){
 }
 
 /**
+ * Change EMT safe tags
+ * with checking result of filter 'no_texturize_tags'
+ * @global EMTypograph $ram108_typo
+ * @param array $old Tags list before run filter
+ * @param array $new Tags list after run filter
+ */
+function EMT_safe_tags ( $old, $new ) {
+	global $ram108_typo;
+	
+	// Check for changes
+	$added_tags = array_diff( $old, $new );
+	$removed_tags = array_diff( $new, $old );
+	
+	if ( count( $added_tags ) > 0 ) {
+		foreach( $added_tags as $tag_to_add ) {
+			$ram108_typo->add_safe_tag($tag_to_add);
+		}
+	}
+	
+	if ( count( $removed_tags ) > 0 ) {
+		foreach( $removed_tags as $tag_to_remove ) {
+			$ram108_typo->remove_safe_block( $tag_to_remove );
+		}
+	}
+}
+
+/**
  * Change all wptexturize filters to EMT_wptexturize
  * @global string $wp_filter
  */


### PR DESCRIPTION
Now we can use standart filters with Web Typography Standards:
    `run_wptexturize`
    `no_texturize_tags`
    `no_texturize_shortcodes`
